### PR TITLE
Add Enclave Support for Github Runners

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -142,6 +142,10 @@ resource "aws_launch_template" "runner" {
   key_name                             = var.key_name
   ebs_optimized                        = var.ebs_optimized
 
+  enclave_options {
+    enabled = var.enclave_options.enabled
+  }
+
   vpc_security_group_ids = !var.associate_public_ipv4_address ? compact(concat(
     var.enable_managed_runner_security_group ? [aws_security_group.runner_sg[0].id] : [],
     var.runner_additional_security_group_ids,

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -661,3 +661,13 @@ variable "enable_on_demand_failover_for_errors" {
   type        = list(string)
   default     = []
 }
+
+variable "enclave_support_options" {
+  description = "Enable Enclave Support for EC2 Instances."
+  type = object({
+    enabled = bool
+  })
+  default = {
+    enabled = false
+  }
+}


### PR DESCRIPTION
- Adds enclave support, needed for Global TEE work. 
- Terraform Reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#enclave-options